### PR TITLE
Update README with correct repo URL and API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ An AI-powered data extraction evaluator agent using LangGraph for property data 
 You can run this tool directly using `uvx`:
 
 ```bash
-uvx --from git+https://github.com/elephant-xyz/agentic_ai test-evaluator-agent
+uvx --from git+https://github.com/elephant-xyz/AI-Agent test-evaluator-agent
 ```
 
 ## Usage
@@ -51,6 +51,7 @@ The agent requires specific directory structure and environment variables:
 # Set environment variables
 export MODEL_NAME=gpt-4.1
 export TEMPERATURE=0
+export OPENAI_API_KEY=your_openai_api_key_here
 
 # Run the agent
 test-evaluator-agent


### PR DESCRIPTION
This PR updates the `README.md` to correct and complete the setup and usage instructions for the agent.

Two key issues were identified in the current documentation:

1.  The `uvx` installation command pointed to an incorrect repository URL (`agentic_ai` instead of `AI-Agent`), which would cause the installation to fail for new users.
2.  The usage example was missing the required `OPENAI_API_KEY` environment variable. Without this, the agent would fail at runtime due to authentication errors with the OpenAI API.

**Changes:**

*   Corrected the repository URL in the `uvx` installation command.
*   Added the `OPENAI_API_KEY` to the list of required environment variables in the usage example.

These changes ensure that new users can successfully install and run the agent by following the provided instructions.